### PR TITLE
Use set_client() instead of passing in a client instance

### DIFF
--- a/backend/arxivsearch/db/load.py
+++ b/backend/arxivsearch/db/load.py
@@ -65,7 +65,7 @@ async def write_async(index: AsyncSearchIndex, papers: list):
     _ = await index.load(
         data=papers,
         preprocess=preprocess_paper,
-        concurrency=config.WRITE_CONCURRENCY,
+        concurrency=int(config.WRITE_CONCURRENCY),
         id_field="id",
     )
 
@@ -74,7 +74,8 @@ async def write_async(index: AsyncSearchIndex, papers: list):
 
 async def load_data():
     # Load schema specs and create index in Redis
-    index = AsyncSearchIndex(redis_helpers.schema, redis_helpers.client)
+    index = AsyncSearchIndex(redis_helpers.schema)
+    await index.set_client(redis_helpers.client)
 
     # Load dataset and create index
     try:


### PR DESCRIPTION
The app won’t start if it’s installed today due a breaking change in AsyncSearchIndex.__ini__():

```
backend-1  | Traceback (most recent call last):
backend-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
backend-1  |   File "<frozen runpy>", line 88, in _run_code
backend-1  |   File "/app/backend/arxivsearch/db/load.py", line 107, in <module>
backend-1  |     asyncio.run(load_data())
backend-1  |   File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
backend-1  |     return runner.run(main)
backend-1  |            ^^^^^^^^^^^^^^^^
backend-1  |   File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
backend-1  |     return self._loop.run_until_complete(task)
backend-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  |   File "/usr/local/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
backend-1  |     return future.result()
backend-1  |            ^^^^^^^^^^^^^^^
backend-1  |   File "/app/backend/arxivsearch/db/load.py", line 77, in load_data
backend-1  |     index = AsyncSearchIndex(redis_helpers.schema, redis_helpers.client)
backend-1  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | TypeError: AsyncSearchIndex.__init__() takes 2 positional arguments but 3 were given
backend-1  | Traceback (most recent call last):
backend-1  |   File "<string>", line 1, in <module>
backend-1  |   File "/app/backend/scripts.py", line 10, in start_app
backend-1  |     subprocess.run(["python", "-m", "arxivsearch.db.load"], check=True)
backend-1  |   File "/usr/local/lib/python3.11/subprocess.py", line 571, in run
backend-1  |     raise CalledProcessError(retcode, process.args,
backend-1  | subprocess.CalledProcessError: Command '['python', '-m', 'arxivsearch.db.load']' returned non-zero exit status ```